### PR TITLE
Remove open3d dependency

### DIFF
--- a/train.py
+++ b/train.py
@@ -10,7 +10,6 @@ from glob import glob
 from accelerate import Accelerator
 
 from chamferdist import ChamferDistance
-import open3d as o3d
 from tqdm import tqdm
 
 from utils import PCDataset, chamfer_distance, EMDLoss, fscore

--- a/utils.py
+++ b/utils.py
@@ -184,19 +184,31 @@ class EMDLoss(nn.Module):
         return emd.mean()
 
 
-import open3d as o3d
 def export_to_ply(point_cloud, filename):
-    """
-    Export a point cloud to a PLY file.
-    :param point_cloud: Numpy array of shape (num_points, 3) representing the point cloud.
-    :param filename: String, the name of the file to save the point cloud to.
-    """
-    # Convert numpy array to Open3D point cloud
-    pcd = o3d.geometry.PointCloud()
-    pcd.points = o3d.utility.Vector3dVector(point_cloud)
+    """Save a point cloud to ``filename`` in ASCII PLY format.
 
-    # Write to a PLY file
-    o3d.io.write_point_cloud(filename, pcd)
+    Parameters
+    ----------
+    point_cloud : numpy.ndarray
+        Array of shape ``(num_points, 3)`` containing xyz coordinates.
+    filename : str
+        Output file path.
+    """
+
+    num_points = point_cloud.shape[0]
+    header = [
+        "ply",
+        "format ascii 1.0",
+        f"element vertex {num_points}",
+        "property float x",
+        "property float y",
+        "property float z",
+        "end_header\n",
+    ]
+
+    with open(filename, "w") as f:
+        f.write("\n".join(header))
+        np.savetxt(f, point_cloud, fmt="%f %f %f")
 
 
 from torchvision import transforms


### PR DESCRIPTION
## Summary
- drop unused open3d import from training script
- replace Open3D-based PLY export with simple ASCII writer

## Testing
- `python -m py_compile train.py utils.py`
- `python inference.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6858f94a3ee483279bd1f8547472b326