### PR TITLE
Fix libGL runtime error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
 
 # install additional apt packages if needed
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y git libgl1 && \
+    rm -rf /var/lib/apt/lists/*
 
 # set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary
- add libgl1 to the Docker image to satisfy Open3D's runtime dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590ad7bb508327b38cfa60d0a7b6e6