### PR TITLE
Fix gsplat rasterization input shapes

### DIFF
--- a/prepare_gs.py
+++ b/prepare_gs.py
@@ -101,9 +101,12 @@ def render_views(data, out_dir, num_views=24, width=224, height=224):
         return torch.from_numpy(c2w).to(pos.device)
 
     # Intrinsic matrix used for all renders
-    intrinsics = torch.tensor(
-        [[800.0, 0.0, width / 2], [0.0, 800.0, height / 2], [0.0, 0.0, 1.0]],
-        device=device,
+    intrinsics = (
+        torch.tensor(
+            [[800.0, 0.0, width / 2], [0.0, 800.0, height / 2], [0.0, 0.0, 1.0]],
+            device=device,
+        )
+        .unsqueeze(0)
     )
 
     for i in range(num_views):
@@ -112,13 +115,13 @@ def render_views(data, out_dir, num_views=24, width=224, height=224):
         eye = center + radius * 2.5 * np.array(
             [np.sin(theta) * np.cos(phi), np.sin(theta) * np.sin(phi), np.cos(theta)]
         )
-        c2w = look_at(eye.astype(np.float32), center.astype(np.float32))
+        c2w = look_at(eye.astype(np.float32), center.astype(np.float32)).unsqueeze(0)
         rgb, _, _ = rasterization(
-            pos,
-            rot,
-            scale,
-            opacity,
-            sh,
+            pos.unsqueeze(0),
+            rot.unsqueeze(0),
+            scale.unsqueeze(0),
+            opacity.unsqueeze(0),
+            sh.unsqueeze(0),
             c2w,
             intrinsics,
             width,

--- a/render_gs.py
+++ b/render_gs.py
@@ -47,18 +47,21 @@ def main():
     scale = torch.from_numpy(data[:, 6 + 43 + 2 : 6 + 43 + 5]).float().to(device)
     rot = torch.from_numpy(data[:, 6 + 43 + 5 : 6 + 43 + 9]).float().to(device)
 
-    cam_pose = torch.eye(4, device=device)
-    intrinsics = torch.tensor(
-        [[800.0, 0.0, args.width / 2], [0.0, 800.0, args.height / 2], [0.0, 0.0, 1.0]],
-        device=device,
+    cam_pose = torch.eye(4, device=device).unsqueeze(0)
+    intrinsics = (
+        torch.tensor(
+            [[800.0, 0.0, args.width / 2], [0.0, 800.0, args.height / 2], [0.0, 0.0, 1.0]],
+            device=device,
+        )
+        .unsqueeze(0)
     )
 
     rgb, _, _ = rasterization(
-        pos,
-        rot,
-        scale,
-        opacity,
-        sh,
+        pos.unsqueeze(0),
+        rot.unsqueeze(0),
+        scale.unsqueeze(0),
+        opacity.unsqueeze(0),
+        sh.unsqueeze(0),
         cam_pose,
         intrinsics,
         args.width,


### PR DESCRIPTION
## Summary
- adjust camera pose and intrinsics to include batch dimension in `render_gs.py`
- add batch dimensions when rendering and in `prepare_gs.py`

## Testing
- `python -m py_compile render_gs.py prepare_gs.py`

------
https://chatgpt.com/codex/tasks/task_e_685910dc9ff88327b9853e0b19d342cc