### PR TITLE
Fix gsplat build by installing GLM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
 
 # install additional apt packages if needed
 RUN apt-get update && \
-    apt-get install -y git libgl1 && \
+    apt-get install -y git libgl1 libglm-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # set working directory

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,12 @@ pip install wandb
 pip install scikit-learn
 pip install gsplat
 ```
+If `gsplat` needs to be compiled from source, make sure the GLM headers
+are available. On Debian-based systems install `libglm-dev`:
+
+```
+apt-get update && apt-get install -y libglm-dev
+```
 
 ## Docker
 You can also run **RGB2Point** using Docker Compose. The provided compose file


### PR DESCRIPTION
## Summary
- install `libglm-dev` in Dockerfile for gsplat build
- document `libglm-dev` requirement when compiling gsplat from source

## Testing
- `python -m py_compile chamferdist.py inference.py prepare_gs.py render_gs.py utils.py model.py train.py`

------
https://chatgpt.com/codex/tasks/task_e_68591c8880488327b1b4644edc39e402