### PR TITLE
Fix training log to report batch loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -124,12 +124,12 @@ if __name__ == "__main__":
 
             if idx % 50 == 0:
                 accelerator.print(
-                    f"[Train|{epoch+1}] {idx}/{len(dataloader)} loss:{np.mean(iou_loss_history):.4f}  cd_loss:{np.mean(cd_history):.4f} "
+                    f"[Train|{epoch+1}] {idx}/{len(dataloader)} loss:{loss.item():.4f}  cd_loss:{cd_loss.item():.4f} "
                 )
                 accelerator.log(
                     {
-                        "train_batch/loss": np.mean(iou_loss_history),
-                        "train_batch/cd_loss": np.mean(cd_history),
+                        "train_batch/loss": loss.item(),
+                        "train_batch/cd_loss": cd_loss.item(),
                     }
                 )
         accelerator.print(


### PR DESCRIPTION
## Summary
- fix training logging so running mean doesn't accumulate

## Testing
- `python -m py_compile train.py`

------
https://chatgpt.com/codex/tasks/task_e_68593159ccf08327b8621d1d3ac9a03a