### PR TITLE
Add timestamped checkpoint directories

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -77,6 +77,12 @@ if __name__ == "__main__":
 
     accelerator.init_trackers(project_name="wacv_pc1024_finetune", config={})
 
+    # create timestamped directory for checkpoints
+    jst = timezone(timedelta(hours=9))
+    timestamp = datetime.now(jst).strftime("%Y%m%d_%H%M%S")
+    save_dir = os.path.join("ckpt", timestamp)
+    os.makedirs(save_dir, exist_ok=True)
+
     chamferDist = ChamferDistance()
     label_table = {
         "02691156": "airplane",
@@ -222,11 +228,11 @@ if __name__ == "__main__":
         accelerator.log(
             {"test/loss": np.mean(loss_history), "cd": cdtable, "test/epoch": epoch + 1}
         )
-        os.makedirs("/ckpt", exist_ok=True)
-        jst = timezone(timedelta(hours=9))
-        timestamp = datetime.now(jst).strftime("%Y%m%d_%H%M%S")
-        model_save_name = f"/ckpt/mymodel_{timestamp}.pth"
+
         score = np.mean(-1 * total_cd)
+        model_save_name = os.path.join(
+            save_dir, f"model_epoch{epoch + 1}_score{score:.4f}.pth"
+        )
         sche.step(score)
         if score < best:
             best = score

--- a/train.py
+++ b/train.py
@@ -67,6 +67,12 @@ if __name__ == "__main__":
 
     accelerator.init_trackers(project_name="wacv_pc1024", config={})
 
+    # create timestamped directory for checkpoints
+    jst = timezone(timedelta(hours=9))
+    timestamp = datetime.now(jst).strftime("%Y%m%d_%H%M%S")
+    save_dir = os.path.join("ckpt", timestamp)
+    os.makedirs(save_dir, exist_ok=True)
+
     chamferDist = ChamferDistance()
     label_table = {
         "02691156": "airplane",
@@ -212,11 +218,11 @@ if __name__ == "__main__":
         accelerator.log(
             {"test/loss": np.mean(loss_history), "cd": cdtable, "test/epoch": epoch + 1}
         )
-        os.makedirs("/ckpt", exist_ok=True)
-        jst = timezone(timedelta(hours=9))
-        timestamp = datetime.now(jst).strftime("%Y%m%d_%H%M%S")
-        model_save_name = f"./ckpt/mymodel_{timestamp}.pth"
+
         score = np.mean(total_cd)
+        model_save_name = os.path.join(
+            save_dir, f"model_epoch{epoch + 1}_score{score:.4f}.pth"
+        )
         sche.step(score)
         print(score)
         if score < best:


### PR DESCRIPTION
## Summary
- organize checkpoint saving
- create timestamped folder inside `ckpt`
- save best checkpoints with epoch and score in file name

## Testing
- `python -m py_compile train.py finetune.py`


------
https://chatgpt.com/codex/tasks/task_e_68596210cfb8832795839711f24af045