### PR TITLE
Save checkpoints every 10 epochs

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -74,6 +74,7 @@ if __name__ == "__main__":
     alpha = 5.0
 
     num_epochs = 1000
+    save_interval = 10
 
     accelerator.init_trackers(project_name="wacv_pc1024_finetune", config={})
 
@@ -234,8 +235,9 @@ if __name__ == "__main__":
             save_dir, f"model_epoch{epoch + 1}_score{score:.4f}.pth"
         )
         sche.step(score)
-        if score < best:
-            best = score
+        if (epoch + 1) % save_interval == 0:
+            if score < best:
+                best = score
             if isinstance(model, nn.DataParallel):
                 data = {
                     "model": model.module.state_dict(),

--- a/train.py
+++ b/train.py
@@ -64,6 +64,7 @@ if __name__ == "__main__":
     alpha = 5.0
 
     num_epochs = 1000
+    save_interval = 10
 
     accelerator.init_trackers(project_name="wacv_pc1024", config={})
 
@@ -225,9 +226,10 @@ if __name__ == "__main__":
         )
         sche.step(score)
         print(score)
-        if score < best:
-            best = score
-            print("model updated")
+        if (epoch + 1) % save_interval == 0:
+            if score < best:
+                best = score
+                print("model updated")
             if isinstance(model, nn.DataParallel):
                 data = {
                     "model": model.module.state_dict(),


### PR DESCRIPTION
## Summary
- add `save_interval` variable
- write checkpoints every 10 epochs in train and finetune scripts

## Testing
- `python -m py_compile train.py finetune.py`

------
https://chatgpt.com/codex/tasks/task_e_68596338e22483279d31daa23079dc88