### PR TITLE
Enable two-image input option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@
 dataset:
   root: data
   categories: ["soybean"]
+  num_views: 1
 
 # Model hyperparameters
 model:
@@ -30,5 +31,5 @@ finetune:
 # Inference
 inference:
   model_path: ckpt/20250623_232126/model_epoch25_score0.0838.pth
-  image_path: img/09.png
+  image_paths: [img/09.png]
   save_path: result/09_2.ply

--- a/finetune.py
+++ b/finetune.py
@@ -62,8 +62,9 @@ if __name__ == "__main__":
     batch_size = cfg.get("training", {}).get("batch_size", 4)
     device = accelerator.device
 
+    num_views = cfg.get("model", {}).get("num_views", 1)
     model = PointCloudNet(
-        num_views=cfg.get("model", {}).get("num_views", 1),
+        num_views=num_views,
         point_cloud_size=cfg.get("model", {}).get("point_cloud_size", 1024),
         num_heads=cfg.get("model", {}).get("num_heads", 4),
         dim_feedforward=cfg.get("model", {}).get("dim_feedforward", 2048)
@@ -114,11 +115,11 @@ if __name__ == "__main__":
     }
 
 
-    dataset = PCDataset(stage="train", transform=transform, root=root, categories=categories)
+    dataset = PCDataset(stage="train", transform=transform, root=root, categories=categories, num_views=num_views)
     dataloader = DataLoader(
         dataset, batch_size=batch_size, shuffle=True, drop_last=True, num_workers=8
     )
-    test_dataset = PCDataset(stage="test", transform=transform, root=root, categories=categories)
+    test_dataset = PCDataset(stage="test", transform=transform, root=root, categories=categories, num_views=num_views)
     test_dataloader = DataLoader(test_dataset, batch_size=1, shuffle=False)
     model, optimizer, dataloader, test_dataloader, sche = accelerator.prepare(
         model, optimizer, dataloader, test_dataloader, sche

--- a/inference.py
+++ b/inference.py
@@ -10,7 +10,7 @@ import yaml
 parser = argparse.ArgumentParser(description="RGB2Point Inference")
 parser.add_argument("--config", default="config.yaml", help="Path to config file")
 parser.add_argument("--model", default=None, help="Model checkpoint path")
-parser.add_argument("--image", default=None, help="Input image")
+parser.add_argument("--images", nargs="+", default=None, help="Input image paths")
 parser.add_argument("--output", default=None, help="Output ply path")
 args = parser.parse_args()
 
@@ -18,7 +18,8 @@ with open(args.config) as f:
     cfg = yaml.safe_load(f)
 
 model_path = args.model if args.model else cfg.get("inference", {}).get("model_path", "ckpt/mymodel.pth")
-image_path = args.image if args.image else cfg.get("inference", {}).get("image_path", "img/09.png")
+image_paths_cfg = cfg.get("inference", {}).get("image_paths", ["img/09.png"])
+image_paths = args.images if args.images else image_paths_cfg
 save_path = args.output if args.output else cfg.get("inference", {}).get("save_path", "result/09_1.ply")
 
 model = PointCloudNet(
@@ -30,5 +31,5 @@ model = PointCloudNet(
 model.load_state_dict(torch.load(model_path)["model"])
 model.eval()
 
-predict(model, image_path, save_path)
+predict(model, image_paths, save_path)
 

--- a/train.py
+++ b/train.py
@@ -56,8 +56,9 @@ if __name__ == "__main__":
     batch_size = cfg.get("training", {}).get("batch_size", 4)
     device = accelerator.device
 
+    num_views = cfg.get("model", {}).get("num_views", 1)
     model = PointCloudNet(
-        num_views=cfg.get("model", {}).get("num_views", 1),
+        num_views=num_views,
         point_cloud_size=cfg.get("model", {}).get("point_cloud_size", 1024),
         num_heads=cfg.get("model", {}).get("num_heads", 4),
         dim_feedforward=cfg.get("model", {}).get("dim_feedforward", 2048),
@@ -104,11 +105,11 @@ if __name__ == "__main__":
     }
 
 
-    dataset = PCDataset(stage="train", transform=transform, root=root, categories=categories)
+    dataset = PCDataset(stage="train", transform=transform, root=root, categories=categories, num_views=num_views)
     dataloader = DataLoader(
         dataset, batch_size=batch_size, shuffle=True, drop_last=True, num_workers=8
     )
-    test_dataset = PCDataset(stage="test", transform=transform, root=root, categories=categories)
+    test_dataset = PCDataset(stage="test", transform=transform, root=root, categories=categories, num_views=num_views)
     test_dataloader = DataLoader(test_dataset, batch_size=1, shuffle=False)
     model, optimizer, dataloader, test_dataloader, sche = accelerator.prepare(
         model, optimizer, dataloader, test_dataloader, sche


### PR DESCRIPTION
## Summary
- support configurable number of input views in `PCDataset`
- update training, finetuning and inference scripts to use the new option
- allow inference with multiple image paths
- update configuration example accordingly

## Testing
- `python -m py_compile train.py finetune.py inference.py utils.py model.py`
- (fails to run runtime tests due to missing PyTorch)

------
https://chatgpt.com/codex/tasks/task_e_686f62d9bee48327ac333bff93d06129