### PR TITLE
Make Docker image self-contained

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 img/
 result/
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ RUN apt-get update && \
     apt-get install -y git libgl1 libglm-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# set working directory
+# set working directory and copy the project
 WORKDIR /app
-# source will be mounted at runtime via docker-compose
+COPY . .
 
 # install python dependencies
 RUN pip install --no-cache-dir timm accelerate wandb scikit-learn gsplat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   app:
     build: .
     volumes:
-      - .:/app
+      - ./data:/app/data
     working_dir: /app
     deploy:
       resources:

--- a/readme.md
+++ b/readme.md
@@ -24,9 +24,11 @@ apt-get update && apt-get install -y libglm-dev
 ```
 
 ## Docker
-You can also run **RGB2Point** using Docker Compose. The provided compose file
-mounts the repository into the container so that changes on the host are
-immediately available.
+You can also run **RGB2Point** using Docker Compose. The compose file now
+includes the training code inside the image and only mounts your dataset from
+`./data` into the container. Place the dataset directory next to the
+`docker-compose.yml` file so that it is available under `/app/data` when the
+container starts.
 
 Build the image and start an interactive session:
 


### PR DESCRIPTION
## Summary
- copy repository files into the Docker image
- mount only the data directory through Docker Compose
- ignore `data/` when building the image
- document new Docker workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687caa6d4948832788c50d4c5eb16313