### PR TITLE
Add support for multiple image extensions

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -75,16 +75,22 @@ class PCDataset(Dataset):
                     label,
                     "pointcloud_2048.npy",
                 )
-                files = glob(
-                    os.path.join(
-                        self.root,
-                        "ShapeNetRendering",
-                        c,
-                        label,
-                        "rendering",
-                        "*.JPG",
+                extensions = ["jpg", "jpeg", "JPG", "JPEG", "png", "PNG"]
+                files = []
+                for ext in extensions:
+                    files.extend(
+                        glob(
+                            os.path.join(
+                                self.root,
+                                "ShapeNetRendering",
+                                c,
+                                label,
+                                "rendering",
+                                f"*.{ext}",
+                            )
+                        )
                     )
-                )
+                files.sort()
                 for file in files:
                     if self.stage == "train":
                         if os.path.exists(volume_path):


### PR DESCRIPTION
## Summary
- accept jpg, jpeg and png images in any case when loading rendering images

## Testing
- `python -m py_compile utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688395f349a88327af15e925030c493b