### PR TITLE
Add best/latest checkpoint directories

### DIFF
--- a/train.py
+++ b/train.py
@@ -81,8 +81,11 @@ if __name__ == "__main__":
     # create timestamped directory for checkpoints
     jst = timezone(timedelta(hours=9))
     timestamp = datetime.now(jst).strftime("%Y%m%d_%H%M%S")
-    save_dir = os.path.join("ckpt", timestamp)
-    os.makedirs(save_dir, exist_ok=True)
+    save_root = os.path.join("ckpt", timestamp)
+    save_dir_best = os.path.join(save_root, "best")
+    save_dir_latest = os.path.join(save_root, "latest")
+    os.makedirs(save_dir_best, exist_ok=True)
+    os.makedirs(save_dir_latest, exist_ok=True)
 
     chamferDist = ChamferDistance()
     label_table = {
@@ -237,7 +240,7 @@ if __name__ == "__main__":
         # score = np.mean(total_cd)
         score = np.mean(loss_history)
         model_save_name = os.path.join(
-            save_dir, f"model_epoch{epoch + 1}_score{score:.4f}.pth"
+            save_dir_best, f"model_epoch{epoch + 1}_score{score:.4f}.pth"
         )
         sche.step(score)
         print(score)
@@ -254,3 +257,20 @@ if __name__ == "__main__":
                     "model": model.state_dict(),
                 }
                 torch.save(data, model_save_name)
+
+        if (epoch + 1) % 10 == 0:
+            latest_name = os.path.join(
+                save_dir_latest, f"model_epoch{epoch + 1}.pth"
+            )
+            for f in os.listdir(save_dir_latest):
+                os.remove(os.path.join(save_dir_latest, f))
+            if isinstance(model, nn.DataParallel):
+                data = {
+                    "model": model.module.state_dict(),
+                }
+                torch.save(data, latest_name)
+            else:
+                data = {
+                    "model": model.state_dict(),
+                }
+                torch.save(data, latest_name)


### PR DESCRIPTION
## Summary
- organize checkpoints under `best` and `latest` folders
- keep the best score models in `best`
- save the model every 10 epochs to `latest`, replacing the previous latest

## Testing
- `python -m py_compile train.py finetune.py`

------
https://chatgpt.com/codex/tasks/task_e_688434ea580083278383c53201e7600e