### PR TITLE
Enable ViT training via config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,7 @@ model:
   point_cloud_size: 2048
   num_heads: 16
   dim_feedforward: 8192
+  train_vit: false
 
 # Training options
 training:

--- a/finetune.py
+++ b/finetune.py
@@ -66,7 +66,8 @@ if __name__ == "__main__":
         num_views=cfg.get("model", {}).get("num_views", 1),
         point_cloud_size=cfg.get("model", {}).get("point_cloud_size", 1024),
         num_heads=cfg.get("model", {}).get("num_heads", 4),
-        dim_feedforward=cfg.get("model", {}).get("dim_feedforward", 2048)
+        dim_feedforward=cfg.get("model", {}).get("dim_feedforward", 2048),
+        train_vit=cfg.get("model", {}).get("train_vit", False)
     )
     if os.path.exists(ckpt_path):
         state = torch.load(ckpt_path)

--- a/inference.py
+++ b/inference.py
@@ -26,6 +26,7 @@ model = PointCloudNet(
     point_cloud_size=cfg.get("model", {}).get("point_cloud_size", 1024),
     num_heads=cfg.get("model", {}).get("num_heads", 4),
     dim_feedforward=cfg.get("model", {}).get("dim_feedforward", 2048),
+    train_vit=cfg.get("model", {}).get("train_vit", False),
 )
 model.load_state_dict(torch.load(model_path)["model"])
 model.eval()

--- a/train.py
+++ b/train.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
         point_cloud_size=cfg.get("model", {}).get("point_cloud_size", 1024),
         num_heads=cfg.get("model", {}).get("num_heads", 4),
         dim_feedforward=cfg.get("model", {}).get("dim_feedforward", 2048),
+        train_vit=cfg.get("model", {}).get("train_vit", False),
     )
     optimizer = optim.Adam(model.parameters(), lr=float(cfg.get("training", {}).get("learning_rate", 5e-4)))
     sched_cfg = cfg.get("training", {}).get("scheduler", {})


### PR DESCRIPTION
## Summary
- add `train_vit` option in `config.yaml`
- allow `PointCloudNet` to optionally train ViT layers
- plumb `train_vit` through train, finetune and inference scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688435c41644832793a5098bac19226c