### PR TITLE
Automatically name inference output after input image

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -1,9 +1,9 @@
-
 from model import PointCloudNet
 from utils import predict
 import torch
 import argparse
 import yaml
+import os
 
 
 
@@ -19,7 +19,18 @@ with open(args.config) as f:
 
 model_path = args.model if args.model else cfg.get("inference", {}).get("model_path", "ckpt/mymodel.pth")
 image_path = args.image if args.image else cfg.get("inference", {}).get("image_path", "img/09.png")
-save_path = args.output if args.output else cfg.get("inference", {}).get("save_path", "result/09_1.ply")
+
+if args.output:
+    save_path = args.output
+else:
+    default_save = cfg.get("inference", {}).get("save_path")
+    # Determine the directory where the ply file will be written
+    if default_save:
+        output_dir = os.path.dirname(default_save) or "."
+    else:
+        output_dir = "result"
+    base_name = os.path.splitext(os.path.basename(image_path))[0]
+    save_path = os.path.join(output_dir, base_name + ".ply")
 
 model = PointCloudNet(
     num_views=cfg.get("model", {}).get("num_views", 1),

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,10 @@ https://drive.google.com/file/d/1Z5luy_833YV6NGiKjGhfsfEUyaQkgua1/view?usp=shari
 python inference.py
 ```
 Settings for the model checkpoint and input/output paths are read from
-`config.yaml`. You can override them on the command line if needed.
+`config.yaml`. You can override them on the command line if needed. When no
+output path is provided, the result is written to the directory specified in
+`config.yaml` (or `result/`) using the input image file name with a `.ply`
+extension.
 
 
 ## Preparing gs data


### PR DESCRIPTION
## Summary
- output filename for inference now defaults to the input image name
- document new behavior in the README

## Testing
- `python -m py_compile inference.py utils.py`
- `python inference.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688b0c7908988327a15e85be4ac045fb