### PR TITLE
Support directory inference

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,3 +39,6 @@ inference:
   model_path: ckpt/20250706_155728/model_epoch9830_score0.0107.pth
   image_path: ./data/ShapeNetRendering/plantonly2/エンレイ4/rendering/エンレイ4_2.JPG
   save_path: result/pi_2_2_0710.ply
+  # Optional folder-based inference settings
+  image_dir: null  # Set to a folder to process all images inside
+  output_dir: result

--- a/inference.py
+++ b/inference.py
@@ -12,25 +12,36 @@ parser.add_argument("--config", default="config.yaml", help="Path to config file
 parser.add_argument("--model", default=None, help="Model checkpoint path")
 parser.add_argument("--image", default=None, help="Input image")
 parser.add_argument("--output", default=None, help="Output ply path")
+parser.add_argument("--dir", default=None, help="Input directory containing images")
+parser.add_argument("--output_dir", default=None, help="Directory to save results when using --dir")
 args = parser.parse_args()
 
 with open(args.config) as f:
     cfg = yaml.safe_load(f)
 
 model_path = args.model if args.model else cfg.get("inference", {}).get("model_path", "ckpt/mymodel.pth")
-image_path = args.image if args.image else cfg.get("inference", {}).get("image_path", "img/09.png")
 
-if args.output:
-    save_path = args.output
+input_dir = args.dir if args.dir else cfg.get("inference", {}).get("image_dir")
+
+if input_dir:
+    output_dir = args.output_dir or cfg.get("inference", {}).get("output_dir")
+    if not output_dir:
+        default_save = cfg.get("inference", {}).get("save_path")
+        output_dir = os.path.dirname(default_save) if default_save else "result"
+    os.makedirs(output_dir, exist_ok=True)
+    image_files = [f for f in os.listdir(input_dir) if f.lower().endswith((".png", ".jpg", ".jpeg"))]
 else:
-    default_save = cfg.get("inference", {}).get("save_path")
-    # Determine the directory where the ply file will be written
-    if default_save:
-        output_dir = os.path.dirname(default_save) or "."
+    image_path = args.image if args.image else cfg.get("inference", {}).get("image_path", "img/09.png")
+    if args.output:
+        save_path = args.output
     else:
-        output_dir = "result"
-    base_name = os.path.splitext(os.path.basename(image_path))[0]
-    save_path = os.path.join(output_dir, base_name + ".ply")
+        default_save = cfg.get("inference", {}).get("save_path")
+        if default_save:
+            output_dir = os.path.dirname(default_save) or "."
+        else:
+            output_dir = "result"
+        base_name = os.path.splitext(os.path.basename(image_path))[0]
+        save_path = os.path.join(output_dir, base_name + ".ply")
 
 model = PointCloudNet(
     num_views=cfg.get("model", {}).get("num_views", 1),
@@ -42,5 +53,11 @@ model = PointCloudNet(
 model.load_state_dict(torch.load(model_path)["model"])
 model.eval()
 
-predict(model, image_path, save_path)
-
+if input_dir:
+    for img in image_files:
+        image_path = os.path.join(input_dir, img)
+        base_name = os.path.splitext(img)[0]
+        save_path = os.path.join(output_dir, base_name + ".ply")
+        predict(model, image_path, save_path)
+else:
+    predict(model, image_path, save_path)

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,14 @@ output path is provided, the result is written to the directory specified in
 `config.yaml` (or `result/`) using the input image file name with a `.ply`
 extension.
 
+To run inference on all images in a directory use the `--dir` option. By
+default results are written to the directory given by `--output_dir` or the
+`output_dir` value in `config.yaml`:
+
+```bash
+python inference.py --dir ./my_images --output_dir ./ply_results
+```
+
 
 ## Preparing gs data
 If you have a directory `gs/` that contains `.ply` files grouped by


### PR DESCRIPTION
## Summary
- add CLI options to process entire image folders in inference script
- update config.yaml with optional folder settings
- document batch inference usage

## Testing
- `python -m py_compile inference.py utils.py model.py train.py finetune.py`

------
https://chatgpt.com/codex/tasks/task_e_688b0d652e40832791f2c6868ab7a110